### PR TITLE
Add stricter enforcement for search keys

### DIFF
--- a/lib/apple/system/logger.rb
+++ b/lib/apple/system/logger.rb
@@ -232,6 +232,7 @@ module Apple
 
         query.each do |key, value|
           asl_key = map_key_to_asl_key(key)
+
           flags = ASL_QUERY_OP_EQUAL
           flags = (flags | ASL_QUERY_OP_NUMERIC) if value.is_a?(Numeric)
           flags = (flags | ASL_QUERY_OP_TRUE) if value == true
@@ -292,7 +293,7 @@ module Apple
           :gid => ASL_KEY_GID,
           :level => ASL_KEY_LEVEL,
           :message => ASL_KEY_MSG
-        }[key]
+        }.fetch(key)
       end
     end
   end

--- a/spec/apple-system-logger_spec.rb
+++ b/spec/apple-system-logger_spec.rb
@@ -123,5 +123,9 @@ RSpec.describe Apple::System::Logger do
       expect(result.first).to be_a(Hash)
       expect(result.size).to be >= 1
     end
+
+    example 'search keys must be valid' do
+      expect{ log.search(:bogus => 'bootlog') }.to raise_error(KeyError)
+    end
   end
 end


### PR DESCRIPTION
Previously a bogus key would pass nil to the underlying asl_search function, which I think then defaulted to returning everything.

This PR adds stricter enforcement simply by replacing `Hash#[]` with `Hash#fetch` in our private conversion method.